### PR TITLE
Remove Shortcode Tags from the Search Index

### DIFF
--- a/index.php
+++ b/index.php
@@ -91,6 +91,9 @@ class Index extends Plugin
         # Remove TOC
         $content = str_replace('[TOC]', '', $content);
 
+		# Remove Shortcodes
+        $content = preg_replace('/\[:.*:\]/m', '', $content);
+		
         # Remove horizontal rules
         $content = preg_replace('/^(-\s*?|\*\s*?|_\s*?){3,}\s*$/m', '', $content);
 

--- a/index.php
+++ b/index.php
@@ -91,7 +91,7 @@ class Index extends Plugin
         # Remove TOC
         $content = str_replace('[TOC]', '', $content);
 
-		# Remove Shortcodes
+	# Remove Shortcodes
         $content = preg_replace('/\[:.*:\]/m', '', $content);
 		
         # Remove horizontal rules


### PR DESCRIPTION
Currently, the search index contains also shortcode tags that do not get rendered, so I think it would be good to remove them completely.