### PR TITLE
Update search.js

### DIFF
--- a/public/search.js
+++ b/public/search.js
@@ -24,7 +24,7 @@ function runSearch(event) {
     return;
   }
 	
-	var results = searchIndex.search(term);
+	var results = searchIndex.search(`${term}^100 ${term}*^10`);
 
 	var resultPages = results.map(function (match)
 	{


### PR DESCRIPTION
Search for term and term* at once with different ratings.

Not sure if this is really the best way to solve my issue:
We are testing typemill and typemill-search for our (german) company manual. Typemill is absolutely awesome! But the search plugin return unpredictable results. 

For example, our texts contain both the words "Eltern" and "Elternzeit". The default plugin returns both results only if we search for "Elt*". Searching for "Elte" only returns matches containing "Eltern", while searching for "Elte*" returns only matches containing "Elternzeit". We tried a lot of combinations of search terms with and without asterisk, and after some googling I stumbled across a post that suggested to automatically input the term both with and without wildcard. 

We did not test throroughly, and there might be better ways to solve this. Anyway, it would be really cool if the search could be improved here, either with this pull request or with a better solution.

Thanks a lot!